### PR TITLE
Fix per download di immagini non funzionante su Safari

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module LifeAtDE
     config.api_only = true
 
     # Configure paths to be escluded from authentication
-    auth_excluded_path = %w(/api/login)
+    auth_excluded_path = %w(/api/login /rails/active_storage/disk)
     config.middleware.use JWTAuth, auth_excluded_path
   end
 end


### PR DESCRIPTION
Inseriti tra gli URL esclusi dal controllo dell'autenticazione tutti gli URL temporanei che vengono creati da Active Storage per fornire i files richiesti da una precedente GET (che deve essere autenticata).
Manovra necessaria in quanto, con Active Storage, la response alla GET di un file è una redirect ad un URL temporaneo. Per una questione di sicurezza quando Safari segue un redirect non permette di utilizzare l'Authorization Header HTTP.

Restiamo comunque con la prima GET che deve essere autenticata. Abbiamo le mani legati e questo è il compromesso migliore al momento.